### PR TITLE
Obtain the GitHub token from the 1Password CLI `gh` plugin

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1857,12 +1857,12 @@ to set a hotkey to clone the repo in the frontmost browser tab</string>
 				<key>required</key>
 				<false/>
 				<key>text</key>
-				<string></string>
+				<string>Use token from 1Password</string>
 			</dict>
 			<key>description</key>
 			<string>Optional. Use the GitHub Personal Access Token configured for use with the `op` plugin. This checkbox will override the static GitHub token configured above.</string>
 			<key>label</key>
-			<string>Token from 1Password</string>
+			<string></string>
 			<key>type</key>
 			<string>checkbox</string>
 			<key>variable</key>

--- a/info.plist
+++ b/info.plist
@@ -1866,7 +1866,7 @@ to set a hotkey to clone the repo in the frontmost browser tab</string>
 			<key>type</key>
 			<string>checkbox</string>
 			<key>variable</key>
-			<string>use_op_plugin</string>
+			<string>github_token_from_op_plugin</string>
 		</dict>
 		<dict>
 			<key>config</key>

--- a/info.plist
+++ b/info.plist
@@ -1860,7 +1860,7 @@ to set a hotkey to clone the repo in the frontmost browser tab</string>
 				<string></string>
 			</dict>
 			<key>description</key>
-			<string>Use the GitHub Personal Access Token configured for use with the `op` plugin</string>
+			<string>Optional. Use the GitHub Personal Access Token configured for use with the `op` plugin. This checkbox will override the static GitHub token configured above.</string>
 			<key>label</key>
 			<string>Token from 1Password</string>
 			<key>type</key>

--- a/info.plist
+++ b/info.plist
@@ -1853,6 +1853,25 @@ to set a hotkey to clone the repo in the frontmost browser tab</string>
 			<key>config</key>
 			<dict>
 				<key>default</key>
+				<false/>
+				<key>required</key>
+				<false/>
+				<key>text</key>
+				<string></string>
+			</dict>
+			<key>description</key>
+			<string>Use the GitHub Personal Access Token configured for use with the `op` plugin</string>
+			<key>label</key>
+			<string>Token from 1Password</string>
+			<key>type</key>
+			<string>checkbox</string>
+			<key>variable</key>
+			<string>use_op_plugin</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
 				<string>gh</string>
 				<key>placeholder</key>
 				<string>gh</string>

--- a/scripts/clone-repo.sh
+++ b/scripts/clone-repo.sh
@@ -102,13 +102,13 @@ fi
 
 # INFO Alfred stores checkbox settings as `"1"` or `"0"`, and variables in stringified form.
 if [[ "$ownerOfRepo" != "true" && "$fork_on_clone" == "1" ]]; then
-	GH=gh
-	if [[ "$github_token_from_op_plugin" == "1" ]]; then
-		GH="op plugin run -- gh"
-	fi
 
 	if [[ -x "$(command -v gh)" ]]; then
-		$GH repo fork --remote=false &> /dev/null
+		if [[ "$github_token_from_op_plugin" == "1" ]]; then
+			op plugin run -- gh repo fork --remote=false &> /dev/null
+		else
+			gh repo fork --remote=false &> /dev/null
+		fi
 	else
 		echo "ERROR: Cannot fork, \`gh\` not installed."
 	fi

--- a/scripts/clone-repo.sh
+++ b/scripts/clone-repo.sh
@@ -103,7 +103,7 @@ fi
 # INFO Alfred stores checkbox settings as `"1"` or `"0"`, and variables in stringified form.
 if [[ "$ownerOfRepo" != "true" && "$fork_on_clone" == "1" ]]; then
 	GH=gh
-	if [[ "$github_token_from_op_plugin" == "true" ]]; then
+	if [[ "$github_token_from_op_plugin" == "1" ]]; then
 		GH="op plugin run -- gh"
 	fi
 

--- a/scripts/clone-repo.sh
+++ b/scripts/clone-repo.sh
@@ -102,6 +102,9 @@ fi
 
 # INFO Alfred stores checkbox settings as `"1"` or `"0"`, and variables in stringified form.
 if [[ "$ownerOfRepo" != "true" && "$fork_on_clone" == "1" ]]; then
+	if [[ "$github_token_from_op_plugin" == "true" ]]; then
+		GITHUB_TOKEN=$(./op_github_token.sh)
+	fi
 
 	if [[ -x "$(command -v gh)" ]]; then
 		gh repo fork --remote=false &> /dev/null

--- a/scripts/clone-repo.sh
+++ b/scripts/clone-repo.sh
@@ -102,12 +102,13 @@ fi
 
 # INFO Alfred stores checkbox settings as `"1"` or `"0"`, and variables in stringified form.
 if [[ "$ownerOfRepo" != "true" && "$fork_on_clone" == "1" ]]; then
+	GH=gh
 	if [[ "$github_token_from_op_plugin" == "true" ]]; then
-		GITHUB_TOKEN=$(./op_github_token.sh)
+		GH="op plugin run -- gh"
 	fi
 
 	if [[ -x "$(command -v gh)" ]]; then
-		gh repo fork --remote=false &> /dev/null
+		$GH repo fork --remote=false &> /dev/null
 	else
 		echo "ERROR: Cannot fork, \`gh\` not installed."
 	fi

--- a/scripts/github-notifications.js
+++ b/scripts/github-notifications.js
@@ -55,9 +55,10 @@ function humanRelativeDate(isoDateStr) {
 // biome-ignore lint/correctness/noUnusedVariables: Alfred run
 function run() {
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
+	const githubTokenFromOpPlugin = $.getenv("github_token_from_op_plugin") === "1";
 	const opTokenShellCmd = "command -v op >/dev/null && op plugin run -- gh auth token"
 	const githubToken =
-		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
+		(githubTokenFromOpPlugin && app.doShellScript(opTokenShellCmd).trim()) || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 	const showReadNotifs =
 		$.NSProcessInfo.processInfo.environment.objectForKey("mode").js === "show-read-notifications";
 

--- a/scripts/github-notifications.js
+++ b/scripts/github-notifications.js
@@ -55,8 +55,9 @@ function humanRelativeDate(isoDateStr) {
 // biome-ignore lint/correctness/noUnusedVariables: Alfred run
 function run() {
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
+	const opTokenShellCmd = "./op-github-token.sh"
 	const githubToken =
-		$.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
+		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 	const showReadNotifs =
 		$.NSProcessInfo.processInfo.environment.objectForKey("mode").js === "show-read-notifications";
 

--- a/scripts/github-notifications.js
+++ b/scripts/github-notifications.js
@@ -55,7 +55,7 @@ function humanRelativeDate(isoDateStr) {
 // biome-ignore lint/correctness/noUnusedVariables: Alfred run
 function run() {
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
-	const opTokenShellCmd = "op plugin run -- gh auth token"
+	const opTokenShellCmd = "command -v op >/dev/null && op plugin run -- gh auth token"
 	const githubToken =
 		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 	const showReadNotifs =

--- a/scripts/github-notifications.js
+++ b/scripts/github-notifications.js
@@ -55,7 +55,7 @@ function humanRelativeDate(isoDateStr) {
 // biome-ignore lint/correctness/noUnusedVariables: Alfred run
 function run() {
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
-	const opTokenShellCmd = "./op-github-token.sh"
+	const opTokenShellCmd = "./scripts/op-github-token.sh"
 	const githubToken =
 		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 	const showReadNotifs =

--- a/scripts/github-notifications.js
+++ b/scripts/github-notifications.js
@@ -55,7 +55,7 @@ function humanRelativeDate(isoDateStr) {
 // biome-ignore lint/correctness/noUnusedVariables: Alfred run
 function run() {
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
-	const opTokenShellCmd = "./scripts/op-github-token.sh"
+	const opTokenShellCmd = "op plugin run -- gh auth token"
 	const githubToken =
 		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 	const showReadNotifs =

--- a/scripts/my-github-prs.js
+++ b/scripts/my-github-prs.js
@@ -62,7 +62,7 @@ function humanRelativeDate(isoDateStr) {
 function run() {
 	const username = $.getenv("github_username");
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
-	const opTokenShellCmd = "./op-github-token.sh"
+	const opTokenShellCmd = "./scripts/op-github-token.sh"
 	const githubToken =
 		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 

--- a/scripts/my-github-prs.js
+++ b/scripts/my-github-prs.js
@@ -62,8 +62,9 @@ function humanRelativeDate(isoDateStr) {
 function run() {
 	const username = $.getenv("github_username");
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
+	const opTokenShellCmd = "./op-github-token.sh"
 	const githubToken =
-		$.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
+		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 
 	const apiUrl = `https://api.github.com/search/issues?q=author:${username}+is:pr+is:open&per_page=100`;
 	const headers = ["Accept: application/vnd.github.json", "X-GitHub-Api-Version: 2022-11-28"];

--- a/scripts/my-github-prs.js
+++ b/scripts/my-github-prs.js
@@ -62,7 +62,7 @@ function humanRelativeDate(isoDateStr) {
 function run() {
 	const username = $.getenv("github_username");
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
-	const opTokenShellCmd = "op plugin run -- gh auth token"
+	const opTokenShellCmd = "command -v op >/dev/null && op plugin run -- gh auth token"
 	const githubToken =
 		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 

--- a/scripts/my-github-prs.js
+++ b/scripts/my-github-prs.js
@@ -62,9 +62,10 @@ function humanRelativeDate(isoDateStr) {
 function run() {
 	const username = $.getenv("github_username");
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
+	const githubTokenFromOpPlugin = $.getenv("github_token_from_op_plugin") === "1";
 	const opTokenShellCmd = "command -v op >/dev/null && op plugin run -- gh auth token"
 	const githubToken =
-		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
+		(githubTokenFromOpPlugin && app.doShellScript(opTokenShellCmd).trim()) || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 
 	const apiUrl = `https://api.github.com/search/issues?q=author:${username}+is:pr+is:open&per_page=100`;
 	const headers = ["Accept: application/vnd.github.json", "X-GitHub-Api-Version: 2022-11-28"];

--- a/scripts/my-github-prs.js
+++ b/scripts/my-github-prs.js
@@ -62,7 +62,7 @@ function humanRelativeDate(isoDateStr) {
 function run() {
 	const username = $.getenv("github_username");
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
-	const opTokenShellCmd = "./scripts/op-github-token.sh"
+	const opTokenShellCmd = "op plugin run -- gh auth token"
 	const githubToken =
 		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 

--- a/scripts/my-github-repos.js
+++ b/scripts/my-github-repos.js
@@ -44,7 +44,7 @@ function run() {
 	const cloneDepth = Number.parseInt($.getenv("clone_depth"));
 	const shallowClone = cloneDepth > 0;
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
-	const opTokenShellCmd = "./op-github-token.sh"
+	const opTokenShellCmd = "./scripts/op-github-token.sh"
 	const githubToken =
 		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 	const useAlfredFrecency = $.getenv("use_alfred_frecency") === "1";

--- a/scripts/my-github-repos.js
+++ b/scripts/my-github-repos.js
@@ -44,9 +44,10 @@ function run() {
 	const cloneDepth = Number.parseInt($.getenv("clone_depth"));
 	const shallowClone = cloneDepth > 0;
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
+	const githubTokenFromOpPlugin = $.getenv("github_token_from_op_plugin") === "1";
 	const opTokenShellCmd = "command -v op >/dev/null && op plugin run -- gh auth token"
 	const githubToken =
-		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
+		(githubTokenFromOpPlugin && app.doShellScript(opTokenShellCmd).trim()) || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 	const useAlfredFrecency = $.getenv("use_alfred_frecency") === "1";
 
 	// determine local repos

--- a/scripts/my-github-repos.js
+++ b/scripts/my-github-repos.js
@@ -44,7 +44,7 @@ function run() {
 	const cloneDepth = Number.parseInt($.getenv("clone_depth"));
 	const shallowClone = cloneDepth > 0;
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
-	const opTokenShellCmd = "op plugin run -- gh auth token"
+	const opTokenShellCmd = "command -v op >/dev/null && op plugin run -- gh auth token"
 	const githubToken =
 		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 	const useAlfredFrecency = $.getenv("use_alfred_frecency") === "1";

--- a/scripts/my-github-repos.js
+++ b/scripts/my-github-repos.js
@@ -44,7 +44,7 @@ function run() {
 	const cloneDepth = Number.parseInt($.getenv("clone_depth"));
 	const shallowClone = cloneDepth > 0;
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
-	const opTokenShellCmd = "./scripts/op-github-token.sh"
+	const opTokenShellCmd = "op plugin run -- gh auth token"
 	const githubToken =
 		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 	const useAlfredFrecency = $.getenv("use_alfred_frecency") === "1";

--- a/scripts/my-github-repos.js
+++ b/scripts/my-github-repos.js
@@ -44,8 +44,9 @@ function run() {
 	const cloneDepth = Number.parseInt($.getenv("clone_depth"));
 	const shallowClone = cloneDepth > 0;
 	const tokenShellCmd = "test -e $HOME/.zshenv && source $HOME/.zshenv ; echo $GITHUB_TOKEN";
+	const opTokenShellCmd = "./op-github-token.sh"
 	const githubToken =
-		$.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
+		app.doShellScript(opTokenShellCmd).trim() || $.getenv("github_token_from_alfred_prefs").trim() || app.doShellScript(tokenShellCmd).trim();
 	const useAlfredFrecency = $.getenv("use_alfred_frecency") === "1";
 
 	// determine local repos

--- a/scripts/op-github-token.sh
+++ b/scripts/op-github-token.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env zsh
 # shellcheck disable=2154,SC1071
 
-echo $(op plugin run -- gh auth status --show-token | grep 'Token: ' | sed 's/.*: \(.*\)/\1/')
+if [[ "$github_token_from_op_plugin" == "true" ]]; then
+    echo $(op plugin run -- gh auth status --show-token | grep 'Token: ' | sed 's/.*: \(.*\)/\1/')
+fi

--- a/scripts/op-github-token.sh
+++ b/scripts/op-github-token.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+# shellcheck disable=2154,SC1071
+
+echo $(op plugin run -- gh auth status --show-token | grep 'Token: ' | sed 's/.*: \(.*\)/\1/')

--- a/scripts/op-github-token.sh
+++ b/scripts/op-github-token.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env zsh
 # shellcheck disable=2154,SC1071
 
-if [[ "$github_token_from_op_plugin" == "true" ]]; then
-    echo $(op plugin run -- gh auth status --show-token | grep 'Token: ' | sed 's/.*: \(.*\)/\1/')
-fi
+echo $(op plugin run -- gh auth status --show-token | grep 'Token: ' | sed 's/.*: \(.*\)/\1/')

--- a/scripts/op-github-token.sh
+++ b/scripts/op-github-token.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env zsh
-# shellcheck disable=2154,SC1071
-
-echo $(op plugin run -- gh auth status --show-token | grep 'Token: ' | sed 's/.*: \(.*\)/\1/')

--- a/scripts/resolve-notification.sh
+++ b/scripts/resolve-notification.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 # shellcheck disable=2154
 
-if [[ "$github_token_from_op_plugin" == "true" ]]; then
+if [[ "$github_token_from_op_plugin" == "1" ]]; then
 	GITHUB_TOKEN=$(op plugin run -- gh auth token)
 fi
 

--- a/scripts/resolve-notification.sh
+++ b/scripts/resolve-notification.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=2154
 
 if [[ "$github_token_from_op_plugin" == "true" ]]; then
-	GITHUB_TOKEN=$(./op_github_token.sh)
+	GITHUB_TOKEN=$(op plugin run -- gh auth token)
 fi
 
 # MARK AS READ

--- a/scripts/resolve-notification.sh
+++ b/scripts/resolve-notification.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env zsh
 # shellcheck disable=2154
 
+if [[ "$github_token_from_op_plugin" == "true" ]]; then
+	GITHUB_TOKEN=$(./op_github_token.sh)
+fi
+
 # MARK AS READ
 if [[ "$mode" == "mark-as-read" ]]; then
 	# DOCS https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#mark-a-thread-as-read


### PR DESCRIPTION
## What problem does this PR solve?

The existing means for obtaining the `GITHUB_TOKEN` rely on the info being stored in a static file on disk (`~/.zshenv` or the `prefs.plist` in the installed workflow), either of which could have the overly permissive permissions.  For example, the `prefs.plist` is created with world readable permission.

## How does the PR solve it?

This change allows the GitHub token to be retrieved from 1Password when the [GitHub shell plugin](https://developer.1password.com/docs/cli/shell-plugins/github/) has been configured.  Ticking the "Use token from 1Password" in the configuration UI enables the functionality, which relies on the `op` 1Password CLI tool.

## Checklist
- [ ] Used only `camelCase` variable names.
- [ ] If functionality is added or modified, also made respective changes to the
  `README.md` and the internal workflow documentation.
